### PR TITLE
Fixing box size issue for linear inflow

### DIFF
--- a/amr-wind/boundary_conditions/LinearInflow.cpp
+++ b/amr-wind/boundary_conditions/LinearInflow.cpp
@@ -58,7 +58,9 @@ void LinearInflow::apply_bc(
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
     for (amrex::MFIter mfi(mfab, mfi_info); mfi.isValid(); ++mfi) {
-        const auto& bx = mfi.validbox();
+	const auto& bx1 = mfi.validbox();
+        int growdir = idim ? 0 : 1;
+        const auto& bx = amrex::grow(bx1,growdir,1);
         const auto& bc_a = mfab.array(mfi);
 
         if (islow && (bx.smallEnd(idim) == domain.smallEnd(idim))) {


### PR DESCRIPTION
The box size issue for the linear inflow has been fixed. The figures show the contours of z-velocity before and after the fix.
![WithOutFix](https://user-images.githubusercontent.com/34353555/94407037-22de8b00-0130-11eb-9a15-85d5e4b65682.png)
![WithFix](https://user-images.githubusercontent.com/34353555/94407044-2540e500-0130-11eb-89dd-efaa520efd8d.png)

