### PR TITLE
overset fixes

### DIFF
--- a/amr-wind/equation_systems/icns/icns_ops.H
+++ b/amr-wind/equation_systems/icns/icns_ops.H
@@ -47,8 +47,11 @@ struct FieldRegOp<ICNS, Scheme>
             repo.mesh(), time, probtype);
         grad_p.template register_fill_patch_op<FieldFillPatchOps<FieldBCNoOp>>(
             repo.mesh(), time, probtype);
-        pressure.template register_fill_patch_op<FieldFillConstScalar>(0.0);
-
+        //pressure.template register_fill_patch_op<FieldFillConstScalar>(0.0);
+        // fixme this is only necessary since tioga does not fill in ghosts
+        // convert back later
+        pressure.template register_fill_patch_op<FieldFillPatchOps<FieldBCNoOp>>(
+            repo.mesh(), time, probtype);
         rho.fillpatch_on_regrid() = true;
         grad_p.fillpatch_on_regrid() = true;
 

--- a/amr-wind/overset/TiogaInterface.cpp
+++ b/amr-wind/overset/TiogaInterface.cpp
@@ -105,6 +105,9 @@ void TiogaInterface::register_solution()
     m_qnode = repo.create_scratch_field(
         pres.num_comp(), pres.num_grow()[0], pres.field_location());
 
+    vel.fillpatch(0.0);
+    pres.fillpatch(0.0);
+
     field_ops::copy(*m_qcell, vel, 0, 0, vel.num_comp(), vel.num_grow());
     field_ops::copy(*m_qnode, pres, 0, 0, pres.num_comp(), pres.num_grow());
 }

--- a/amr-wind/overset/TiogaInterface.cpp
+++ b/amr-wind/overset/TiogaInterface.cpp
@@ -112,7 +112,7 @@ void TiogaInterface::register_solution()
 void TiogaInterface::update_solution()
 {
     auto& repo = m_sim.repo();
-    auto& vel = repo.get_field("velocity");
+    auto& vel = repo.get_field("velocity").state(amr_wind::FieldState::Old);
     auto& pres = repo.get_field("p");
 
     field_ops::copy(vel, *m_qcell, 0, 0, vel.num_comp(), vel.num_grow());
@@ -160,6 +160,12 @@ void TiogaInterface::update_solution()
         }
     }
 #endif
+
+    // fixme this is only necessary because tioga does
+    // not fill in ghosts yet
+    vel.fillpatch(0.0);
+    pres.fillpatch(0.0);
+
 }
 
 void TiogaInterface::amr_to_tioga_mesh()


### PR DESCRIPTION
- added fill patch's so that we get the same answer when using patch independent solutions
- should be able to eliminate some fillpatch after Tioga can update ghosts
- update solution uses old velocity now since incflo advance expects velocity to be in the old state 